### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -12,34 +12,34 @@ phases:
       - python3 -m virtualenv MXNet
       - source MXNet/bin/activate
       - pip install mxnet==1.4.0.post0
-      - rm -rf $(find MXNet/lib/python3.7/site-packages/numpy -name tests)
-      - cp -r MXNet/lib/python3.7/site-packages/* mxnet/python
+      - rm -rf $(find MXNet/lib/python3.10/site-packages/numpy -name tests)
+      - cp -r MXNet/lib/python3.10/site-packages/* mxnet/python
       - rm -rf mxnet/python/pip*
       - rm -rf mxnet/python/wheel*
       - rm -rf mxnet/python/setuptools*
       - rm -rf mxnet/python/pkg_resources
       - pip install keras-mxnet==2.2.4.1 Pillow==6.0.0 gluonnlp==0.6.0 gluoncv==0.4.0.post0 scikit-learn==0.21.3 matplotlib==3.0.3 six==1.12.0 cycler==0.10.0 kiwisolver==1.1.0 pyparsing==2.4.0
-      - rm -rf $(find MXNet/lib/python3.7/site-packages/ -name tests)
-      - cp -r MXNet/lib/python3.7/site-packages/six* keras/python
-      - cp -r MXNet/lib/python3.7/site-packages/h5py* keras/python
-      - cp -r MXNet/lib/python3.7/site-packages/yaml* keras/python
-      - cp -r MXNet/lib/python3.7/site-packages/keras* keras/python
-      - cp -r MXNet/lib/python3.7/site-packages/scipy* scipy/python
-      - cp -r MXNet/lib/python3.7/site-packages/keras_mxnet* keras/python
-      - cp -r MXNet/lib/python3.7/site-packages/PIL* pillow/python
-      - cp -r MXNet/lib/python3.7/site-packages/gluonnlp gluonnlp/python
-      - cp -r MXNet/lib/python3.7/site-packages/gluoncv* gluoncv/python
-      - cp -r MXNet/lib/python3.7/site-packages/pyparsing* gluoncv/python
-      - cp -r MXNet/lib/python3.7/site-packages/yaml* gluoncv/python
-      - cp -r MXNet/lib/python3.7/site-packages/kiwisolver* gluoncv/python
-      - cp -r MXNet/lib/python3.7/site-packages/cycler* gluoncv/python
-      - cp -r MXNet/lib/python3.7/site-packages/six* gluoncv/python
-      - cp -r MXNet/lib/python3.7/site-packages/tqdm* gluoncv/python
-      - cp -r MXNet/lib/python3.7/site-packages/matplotlib* gluoncv/python
-      - cp -r MXNet/lib/python3.7/site-packages/mpl_toolkits* gluoncv/python
-      - cp -r MXNet/lib/python3.7/site-packages/sklearn* sklearn/python
-      - cp -r MXNet/lib/python3.7/site-packages/joblib* sklearn/python
-      - cp -r MXNet/lib/python3.7/site-packages/numpy* sklearn/python
+      - rm -rf $(find MXNet/lib/python3.10/site-packages/ -name tests)
+      - cp -r MXNet/lib/python3.10/site-packages/six* keras/python
+      - cp -r MXNet/lib/python3.10/site-packages/h5py* keras/python
+      - cp -r MXNet/lib/python3.10/site-packages/yaml* keras/python
+      - cp -r MXNet/lib/python3.10/site-packages/keras* keras/python
+      - cp -r MXNet/lib/python3.10/site-packages/scipy* scipy/python
+      - cp -r MXNet/lib/python3.10/site-packages/keras_mxnet* keras/python
+      - cp -r MXNet/lib/python3.10/site-packages/PIL* pillow/python
+      - cp -r MXNet/lib/python3.10/site-packages/gluonnlp gluonnlp/python
+      - cp -r MXNet/lib/python3.10/site-packages/gluoncv* gluoncv/python
+      - cp -r MXNet/lib/python3.10/site-packages/pyparsing* gluoncv/python
+      - cp -r MXNet/lib/python3.10/site-packages/yaml* gluoncv/python
+      - cp -r MXNet/lib/python3.10/site-packages/kiwisolver* gluoncv/python
+      - cp -r MXNet/lib/python3.10/site-packages/cycler* gluoncv/python
+      - cp -r MXNet/lib/python3.10/site-packages/six* gluoncv/python
+      - cp -r MXNet/lib/python3.10/site-packages/tqdm* gluoncv/python
+      - cp -r MXNet/lib/python3.10/site-packages/matplotlib* gluoncv/python
+      - cp -r MXNet/lib/python3.10/site-packages/mpl_toolkits* gluoncv/python
+      - cp -r MXNet/lib/python3.10/site-packages/sklearn* sklearn/python
+      - cp -r MXNet/lib/python3.10/site-packages/joblib* sklearn/python
+      - cp -r MXNet/lib/python3.10/site-packages/numpy* sklearn/python
 artifacts:
   name: mxnet
   base-directory: /root/mxnet

--- a/template.json
+++ b/template.json
@@ -536,7 +536,7 @@
                 "Layers": [
                     { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "RequestsLayer"]}
                 ],
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": "600",
                 "Role": {
                     "Fn::GetAtt": [
@@ -561,7 +561,7 @@
             "Type": "AWS::Lambda::LayerVersion",
             "Properties": {
                 "CompatibleRuntimes": [
-                    "python3.7"
+                    "python3.10"
                 ],
                 "Content": {
                     "S3Bucket": {
@@ -580,7 +580,7 @@
             "Type": "AWS::Lambda::LayerVersion",
             "Properties": {
                 "CompatibleRuntimes": [
-                    "python3.7"
+                    "python3.10"
                 ],
                 "Content": {
                     "S3Bucket": {
@@ -599,7 +599,7 @@
             "Type": "AWS::Lambda::LayerVersion",
             "Properties": {
                 "CompatibleRuntimes": [
-                    "python3.7"
+                    "python3.10"
                 ],
                 "Content": {
                     "S3Bucket": {
@@ -618,7 +618,7 @@
             "Type": "AWS::Lambda::LayerVersion",
             "Properties": {
                 "CompatibleRuntimes": [
-                    "python3.7"
+                    "python3.10"
                 ],
                 "Content": {
                     "S3Bucket": {
@@ -637,7 +637,7 @@
             "Type": "AWS::Lambda::LayerVersion",
             "Properties": {
                 "CompatibleRuntimes": [
-                    "python3.7"
+                    "python3.10"
                 ],
                 "Content": {
                     "S3Bucket": {
@@ -656,7 +656,7 @@
             "Type": "AWS::Lambda::LayerVersion",
             "Properties": {
                 "CompatibleRuntimes": [
-                    "python3.7"
+                    "python3.10"
                 ],
                 "Content": {
                     "S3Bucket": {
@@ -675,7 +675,7 @@
             "Type": "AWS::Lambda::LayerVersion",
             "Properties": {
                 "CompatibleRuntimes": [
-                    "python3.7"
+                    "python3.10"
                 ],
                 "Content": {
                     "S3Bucket": {
@@ -738,7 +738,7 @@
                     "S3Key": "demo/inference.zip"
                 },
                 "Handler": "inference.lambda_handler",
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": "120",
                 "Role": {
                     "Fn::GetAtt": [
@@ -1182,7 +1182,7 @@
                     }
                 },
                 "Handler": "index.cleanup",
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": "600",
                 "Layers": [
                     { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "RequestsLayer"]}


### PR DESCRIPTION
CloudFormation templates in serverless-machine-learning-on-aws have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.